### PR TITLE
Render atlas title above URL

### DIFF
--- a/decoder/compose.py
+++ b/decoder/compose.py
@@ -199,7 +199,7 @@ def add_scale_bar(ctx, mmap, map_height_pt):
 
     ctx.restore()
 
-def add_print_page(ctx, mmap, href, well_bounds_pt, points_FG, hm2pt_ratio, layout, text, mark, fuzzy, indexees):
+def add_print_page(ctx, mmap, href, well_bounds_pt, points_FG, hm2pt_ratio, layout, text, mark, fuzzy, indexees, title):
     """
     """
     print >> sys.stderr, 'Adding print page:', href
@@ -370,6 +370,11 @@ def add_print_page(ctx, mmap, href, well_bounds_pt, points_FG, hm2pt_ratio, layo
 
         ctx.move_to(well_width_pt - text_width, -6)
         ctx.show_text(line)
+
+        title_width = ctx.text_extents(title)[2]
+
+        ctx.move_to(well_width_pt - title_width, -24)
+        ctx.show_text(title)
 
         add_scale_bar(ctx, mmap, map_height_pt)
 

--- a/decoder/create_index.py
+++ b/decoder/create_index.py
@@ -20,7 +20,7 @@ from dimensions import ptpin
 API_BASE = os.getenv('API_BASE_URL', 'http://fieldpapers.org/')
 
 
-def render_index(paper_size, orientation, layout, atlas_id, bounds, envelope, zoom, provider, cols, rows, text):
+def render_index(paper_size, orientation, layout, atlas_id, bounds, envelope, zoom, provider, cols, rows, text, title):
     page_number = "i"
 
     # hm2pt_ratio = homogeneous point coordinate conversation ratio
@@ -69,7 +69,7 @@ def render_index(paper_size, orientation, layout, atlas_id, bounds, envelope, zo
     try:
         (print_context, finish_drawing) = get_drawing_context(print_filename, page_width_pt, page_height_pt)
 
-        add_print_page(print_context, page_mmap, page_href, map_bounds_pt, points_FG, hm2pt_ratio, layout, text, None, None, pages)
+        add_print_page(print_context, page_mmap, page_href, map_bounds_pt, points_FG, hm2pt_ratio, layout, text, None, None, pages, title)
 
         finish_drawing()
 
@@ -121,6 +121,8 @@ if __name__ == '__main__':
                       type='int')
     parser.add_option('-t', '--text', dest='text', default='',
                       help='Body text.')
+    parser.add_option('-T', '--title', dest='title', default='',
+                      help='Title.')
 
     (opts, args) = parser.parse_args()
     if len(args) != 1:
@@ -130,7 +132,7 @@ if __name__ == '__main__':
     client = Client()
 
     try:
-        print render_index(opts.paper_size, opts.orientation, opts.layout, args[0], opts.bounds, opts.envelope, opts.zoom, opts.provider, opts.cols, opts.rows, opts.text)
+        print render_index(opts.paper_size, opts.orientation, opts.layout, args[0], opts.bounds, opts.envelope, opts.zoom, opts.provider, opts.cols, opts.rows, opts.text, opts.title)
     except Exception, e:
         client.captureException()
         raise

--- a/decoder/create_page.py
+++ b/decoder/create_page.py
@@ -20,7 +20,7 @@ from dimensions import ptpin
 API_BASE = os.getenv('API_BASE_URL', 'http://fieldpapers.org/')
 
 
-def render_page(paper_size, orientation, layout, atlas_id, page_number, bounds, zoom, provider, text):
+def render_page(paper_size, orientation, layout, atlas_id, page_number, bounds, zoom, provider, text, title):
     # hm2pt_ratio = homogeneous point coordinate conversation ratio
     (page_width_pt, page_height_pt, points_FG, hm2pt_ratio) = paper_info(paper_size, orientation)
 
@@ -51,7 +51,7 @@ def render_page(paper_size, orientation, layout, atlas_id, page_number, bounds, 
     try:
         (print_context, finish_drawing) = get_drawing_context(print_filename, page_width_pt, page_height_pt)
 
-        add_print_page(print_context, page_mmap, page_href, map_bounds_pt, points_FG, hm2pt_ratio, layout, text, None, None, [])
+        add_print_page(print_context, page_mmap, page_href, map_bounds_pt, points_FG, hm2pt_ratio, layout, text, None, None, [], title)
 
         finish_drawing()
 
@@ -97,6 +97,8 @@ if __name__ == '__main__':
                       help='Page number.')
     parser.add_option('-t', '--text', dest='text', default='',
                       help='Page text.')
+    parser.add_option('-T', '--title', dest='title', default='',
+                      help='Title.')
 
     (opts, args) = parser.parse_args()
     if len(args) != 1:
@@ -106,7 +108,7 @@ if __name__ == '__main__':
     client = Client()
 
     try:
-        render_page(opts.paper_size, opts.orientation, opts.layout, args[0], opts.page_number, opts.bounds, opts.zoom, opts.provider, opts.text)
+        render_page(opts.paper_size, opts.orientation, opts.layout, args[0], opts.page_number, opts.bounds, opts.zoom, opts.provider, opts.text, opts.title)
     except Exception, e:
         client.captureException()
         raise


### PR DESCRIPTION
Adds a `-T` (`--title`) option to the page and index renderers so that a title can be provided for rendering above the URL.

![image](https://cloud.githubusercontent.com/assets/45/14992822/be5f4d98-111c-11e6-8e7e-cb383c838fa1.png)

Refs fieldpapers/fieldpapers#240
